### PR TITLE
#25 Extends host with additional path eg. /hostPath, example url: you…

### DIFF
--- a/Sources/Get/APIClient.swift
+++ b/Sources/Get/APIClient.swift
@@ -22,6 +22,8 @@ public actor APIClient {
 
     public struct Configuration {
         public var host: String
+        /// extends host with additional path eg. /hostPath, host:9009/hostPath
+        public var hostPath: String = ""
         public var port: Int?
         /// If `true`, uses `http` instead of `https`.
         public var isInsecure = false
@@ -136,7 +138,7 @@ public actor APIClient {
     }
 
     private func makeURL(path: String, query: [(String, String?)]?) throws -> URL {
-        guard let url = URL(string: path),
+        guard let url = URL(string: conf.hostPath + path),
               var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             throw URLError(.badURL)
         }


### PR DESCRIPTION
#25 Extends host with additional path eg. /hostPath, example url: yourHost:9009/hostPath/v1/endpointName
Fixes https://github.com/CreateAPI/Get/issues/25