### PR TITLE
Check for non-empty query before creating request

### DIFF
--- a/Sources/Get/APIClient.swift
+++ b/Sources/Get/APIClient.swift
@@ -138,7 +138,8 @@ public actor APIClient {
                 components.port = port
             }
         }
-        if let query = query {
+
+        if let query = query, !query.isEmpty {
             components.queryItems = query.map(URLQueryItem.init)
         }
         guard let url = components.url else {


### PR DESCRIPTION
## Changes

- Set the component's query items only when the query is non-empty.

Without this check the URL is created with a trailing `?` without any query parameter.