### PR TITLE
Fix trailing ? when creating the request with empty query items

### DIFF
--- a/Sources/Get/APIClient.swift
+++ b/Sources/Get/APIClient.swift
@@ -162,7 +162,7 @@ public actor APIClient {
               var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
             throw URLError(.badURL)
         }
-        if let query = query {
+        if let query = query, !query.isEmpty {
             components.queryItems = query.map(URLQueryItem.init)
         }
         guard let url = components.url else {


### PR DESCRIPTION
When creating a request with an empty query params, the request is created with a trailing `?` without any parameter.

This PR adds a fix for setting the component's queryItems only when the query is non-empty.